### PR TITLE
Add missing packages

### DIFF
--- a/workspace/spago.dhall
+++ b/workspace/spago.dhall
@@ -1,6 +1,7 @@
 { name = "cw-purescript"
 , dependencies =
   [ "aff"
+  , "arrays"
   , "bigints"
   , "console"
   , "datetime"
@@ -8,8 +9,14 @@
   , "effect"
   , "either"
   , "enums"
+  , "foldable-traversable"
+  , "gen"
+  , "integers"
+  , "lists"
   , "maybe"
+  , "nonempty"
   , "ordered-collections"
+  , "partial"
   , "prelude"
   , "profunctor-lenses"
   , "quickcheck"
@@ -19,7 +26,9 @@
   , "spec-discovery"
   , "spec-quickcheck"
   , "spec-reporter-codewars"
+  , "strings"
   , "tuples"
+  , "unsafe-coerce"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]


### PR DESCRIPTION
Some kata are failing to update because of error like:

```text
[error] Some of your project files import modules from packages that are not in the direct dependencies of your project.
To fix this error add the following packages to the list of dependencies in your config:
- foldable-traversable
- integers
You may add these dependencies by running the following command:
spago install foldable-traversable integers
```